### PR TITLE
Investigar erro de bucket não encontrado ao anexar

### DIFF
--- a/app/api/storage/ensure-bucket/route.ts
+++ b/app/api/storage/ensure-bucket/route.ts
@@ -1,0 +1,39 @@
+import 'server-only'
+import { NextResponse } from 'next/server'
+import { createServerClient } from '@/lib/supabase/server'
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => ({}))
+    const bucket = (body?.bucket as string) || 'attachments'
+
+    const supabase = createServerClient()
+
+    // Check if bucket exists
+    const { data: existing, error: getError } = await supabase.storage.getBucket(bucket)
+
+    if (getError && !/not found/i.test(getError.message)) {
+      return NextResponse.json({ ok: false, error: getError.message }, { status: 500 })
+    }
+
+    if (!existing) {
+      const { error: createError } = await supabase.storage.createBucket(bucket, {
+        public: true,
+      })
+
+      if (createError) {
+        // If it already exists due to race condition, proceed
+        if (!/already exists/i.test(createError.message)) {
+          return NextResponse.json({ ok: false, error: createError.message }, { status: 500 })
+        }
+      }
+
+      return NextResponse.json({ ok: true, created: true })
+    }
+
+    return NextResponse.json({ ok: true, created: false })
+  } catch (error: any) {
+    return NextResponse.json({ ok: false, error: error?.message || 'Unknown error' }, { status: 500 })
+  }
+}
+

--- a/components/level1-form.tsx
+++ b/components/level1-form.tsx
@@ -77,6 +77,15 @@ export default function Level1Form() {
         const fileName = `${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`
         const path = `tickets/${fileName}`
 
+        // Garante que o bucket exista (servidor cria se necessário)
+        try {
+          await fetch('/api/storage/ensure-bucket', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ bucket: 'attachments' }),
+          })
+        } catch {}
+
         const { data: storageData, error: storageError } = await supabase.storage
           .from('attachments')
           .upload(path, file, { cacheControl: '3600', upsert: false })


### PR DESCRIPTION
Add automatic Supabase 'attachments' bucket creation before file uploads to resolve 'Bucket not found' errors.

The "Bucket not found" error occurred because the 'attachments' storage bucket might not exist in the Supabase project. This PR introduces a new API route (`/api/storage/ensure-bucket`) that checks for the bucket's existence and creates it as public if it's missing, leveraging the Supabase service role. The upload form now calls this route prior to uploading files, guaranteeing the target bucket is available.

---
<a href="https://cursor.com/background-agent?bcId=bc-c2d2f2cc-8f89-47eb-b35e-a990666e59ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c2d2f2cc-8f89-47eb-b35e-a990666e59ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

